### PR TITLE
Enable ability to provide a `key` to auth using `inngest login --token`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,9 +46,9 @@ runs:
         node-version: 16
     - run: npm i -g inngest-cli@${{ inputs.version }}
       shell: ${{ runner.os == 'Windows' && 'cmd' || 'bash' }}
-    # - if: inputs.key != ''
-    #   run: inngest login --token ${{ inputs.key }}
-    #   shell: ${{ runner.os == 'Windows' && 'cmd' || 'bash' }}
+    - if: inputs.key != ''
+      run: inngest login --token ${{ inputs.key }}
+      shell: ${{ runner.os == 'Windows' && 'cmd' || 'bash' }}
     - id: echo-version-cmd
       if: runner.os == 'Windows'
       run: FOR /F %%A IN ('inngest version') DO echo ::set-output name=version::%%~A


### PR DESCRIPTION
Enables the `key` input, allowing auth via `inngest login --token`.

Waiting on inngest/inngest#209, then can merge.